### PR TITLE
skia: add compat SkBitmap::setConfig symbol

### DIFF
--- a/src/core/SkBitmap.cpp
+++ b/src/core/SkBitmap.cpp
@@ -225,6 +225,11 @@ bool SkBitmap::setConfig(Config config, int width, int height, size_t rowBytes,
     SkColorType ct = SkBitmapConfigToColorType(config);
     return this->setInfo(SkImageInfo::Make(width, height, ct, alphaType), rowBytes);
 }
+
+extern "C" void _ZN8SkBitmap9setConfigENS_6ConfigEiii(SkBitmap *bitmap,
+        SkBitmap::Config c, int width, int height, int rowBytes) {
+    bitmap->setConfig(c, width, height, (size_t) rowBytes);
+}
 #endif
 
 bool SkBitmap::setAlphaType(SkAlphaType alphaType) {


### PR DESCRIPTION
Required for older Samsung libtvout and HTC camera.tegra.

Change-Id: Icaae6ca01556553e57c3a194427093c59e0c5f65